### PR TITLE
Baking 2.1.1 for HMF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# HowManyFoxes
+
+A port of HowManyItems to ReIndev, using FoxLoader as modloader.
+
+Also adds recipe viewers for:
+- Carpentry Table
+- Forge
+- Refridgifreezer
+- Some loot tables (Cucurboo Tomb and Dungeon Chest, and Four-Leaf Clover)

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url 'https://cdn.fox2code.com/maven' }
     }
     dependencies {
-        classpath('com.fox2code.FoxLoader:dev:2.0-alpha33')
+        classpath('com.fox2code.FoxLoader:dev:2.0-alpha38')
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 apply plugin: 'foxloader.dev'
 
 group = 'com.fox2code'
-version = '2.1.0'
+version = '2.1.1'
 
 dependencies {
     testImplementation platform('org.junit:junit-bom:5.10.0')

--- a/src/main/java/com/fox2code/howmanyfoxes/hmi/GuiRecipeViewer.java
+++ b/src/main/java/com/fox2code/howmanyfoxes/hmi/GuiRecipeViewer.java
@@ -576,7 +576,8 @@ public class GuiRecipeViewer extends GuiContainer<ContainerRecipeViewer> {
       }
 
       Utils.postRender();
-      Utils.disableLighting();
+      //Utils.disableLighting(); //this whole render code is ugly - it switches on and off lightning with mere manipulations
+      //TODO: Remind me to think about rewriting this code a little bit in the nearby... ahem far future
       GL11.glPopMatrix();
       GL11.glPushMatrix();
       GL11.glRotatef(120.0F, 1.0F, 0.0F, 0.0F);

--- a/src/main/java/com/fox2code/howmanyfoxes/hmi/TabUtils.java
+++ b/src/main/java/com/fox2code/howmanyfoxes/hmi/TabUtils.java
@@ -41,6 +41,11 @@ public class TabUtils {
       freezingTab.equivalentCraftingStations.add(new ItemStack(Blocks.REFRIDGIFREEZER_ACTIVE));
       guiToBlock.put(GuiContainerRefridgifreezer.class, new ItemStack(Blocks.REFRIDGIFREEZER_IDLE));
 
+      //incinerator tab
+       final Tab incineratorTab = new TabIncinerator(mod);
+       tabList.add(incineratorTab);
+       guiToBlock.put(GuiContainerIncinerator.class, new ItemStack(Blocks.INCINERATOR));
+
       //carpenter table tab
       final Tab carpentryTab = new TabCarpentry(mod);
       tabList.add(carpentryTab);

--- a/src/main/java/com/fox2code/howmanyfoxes/hmi/config/HMFKeyBinds.java
+++ b/src/main/java/com/fox2code/howmanyfoxes/hmi/config/HMFKeyBinds.java
@@ -2,15 +2,16 @@ package com.fox2code.howmanyfoxes.hmi.config;
 
 import com.fox2code.foxloader.client.KeyBindingAPI;
 import net.minecraft.client.util.KeyBinding;
+import org.lwjgl.input.Keyboard;
 
 public final class HMFKeyBinds {
-    public static final KeyBinding KEY_GET_RECIPES = new KeyBinding("key.hmf.get-recipes", 19);
-    public static final KeyBinding KEY_GET_USES = new KeyBinding("key.hmf.get-uses", 22);
-    public static final KeyBinding KEY_PREV_RECIPE = new KeyBinding("key.hmf.previous-Recipe", 14);
-    public static final KeyBinding KEY_ALL_RECIPES = new KeyBinding("key.hmf.show-all-recipes", 0);
-    public static final KeyBinding KEY_CLEAR_SEARCHBOX = new KeyBinding("key.hmf.clear-search", 211);
-    public static final KeyBinding KEY_FOCUS_SEARCHBOX = new KeyBinding("key.hmf.focus-search", 28);
-    public static final KeyBinding KEY_TOGGLE_OVERLAY = new KeyBinding("key.hmf.toggle-hmf", 24);
+    public static final KeyBinding KEY_GET_RECIPES = new KeyBinding("key.hmf.get-recipes", Keyboard.KEY_R);
+    public static final KeyBinding KEY_GET_USES = new KeyBinding("key.hmf.get-uses", Keyboard.KEY_U);
+    public static final KeyBinding KEY_PREV_RECIPE = new KeyBinding("key.hmf.previous-Recipe", Keyboard.KEY_BACK);
+    public static final KeyBinding KEY_ALL_RECIPES = new KeyBinding("key.hmf.show-all-recipes", Keyboard.KEY_P);
+    public static final KeyBinding KEY_CLEAR_SEARCHBOX = new KeyBinding("key.hmf.clear-search", Keyboard.KEY_DELETE);
+    public static final KeyBinding KEY_FOCUS_SEARCHBOX = new KeyBinding("key.hmf.focus-search", Keyboard.KEY_RETURN);
+    public static final KeyBinding KEY_TOGGLE_OVERLAY = new KeyBinding("key.hmf.toggle-hmf", Keyboard.KEY_O);
 
     public static final KeyBinding[] HMF_KEYBINDS = new KeyBinding[]{
             HMFKeyBinds.KEY_GET_RECIPES, HMFKeyBinds.KEY_GET_USES, HMFKeyBinds.KEY_PREV_RECIPE, HMFKeyBinds.KEY_ALL_RECIPES,

--- a/src/main/java/com/fox2code/howmanyfoxes/hmi/overlay/GuiOverlay.java
+++ b/src/main/java/com/fox2code/howmanyfoxes/hmi/overlay/GuiOverlay.java
@@ -328,7 +328,7 @@ public class GuiOverlay extends GuiScreen {
                 } else {
                     s = "View All Recipes";
                 }
-            } else if (HowManyFoxes.CONFIG.cheatsEnabled && !this.mc.theWorld.isRemote && this.buttonTrash.mousePressed(this.mc, mouseX, mouseY)) {
+            } else if (HowManyFoxes.CONFIG.cheatsEnabled && !this.mc.theWorld.isRemote && (this.buttonTrash != null && this.buttonTrash.mousePressed(this.mc, mouseX, mouseY))) {
                 if (inventoryplayer.getCursorStack() == null) {
                     if (shiftHeld) {
                         s = "Clear WHOLE inventory";

--- a/src/main/java/com/fox2code/howmanyfoxes/hmi/tabs/TabIncinerator.java
+++ b/src/main/java/com/fox2code/howmanyfoxes/hmi/tabs/TabIncinerator.java
@@ -1,0 +1,156 @@
+package com.fox2code.howmanyfoxes.hmi.tabs;
+
+import com.fox2code.howmanyfoxes.hmi.Utils;
+import net.minecraft.common.block.Blocks;
+import net.minecraft.common.block.data.Materials;
+import net.minecraft.common.block.tileentity.TileEntityIncinerator;
+import net.minecraft.common.item.Item;
+import net.minecraft.common.item.ItemStack;
+import net.minecraft.common.item.Items;
+import net.minecraft.common.item.children.ItemFood;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class TabIncinerator extends TabWithTexture {
+    private final ArrayList<ItemStack> fuels = new ArrayList<>();
+    private final ArrayList<ItemStack[]> recipes = new ArrayList<>();
+
+    public static class DumbIncineratorRecord {
+
+    }
+
+    public TabIncinerator(String tabCreator) {
+        super(
+                tabCreator, 19,
+                "/textures/gui/container/incinerator.png",
+                166, 58,
+                5, 5,
+                5, 14
+        );
+
+        for (int i = 0; i < 9; i++) {
+            this.slots[i] = new Integer[]{
+                    3 + (i % 3) * 18,
+                    6 + (i / 3) * 18
+            };
+        }
+
+        for (int i = 0; i < 9; i++) {
+            this.slots[i + 9] = new Integer[]{
+                    111 + (i % 3) * 18,
+                    6 + (i / 3) * 18
+            };
+        }
+
+        this.slots[18] = new Integer[]{75, 42};
+
+        for (ItemStack item : Utils.itemList()) {
+            if (item == null) continue;
+            if(
+                    (item.getItemID() < 256 && Blocks.BLOCKS_LIST[item.getItemID()].blockMaterial == Materials.WOOD) ||
+                            (item.getItem().getBurnTimeViaType(1) >> 1 > 0)
+            ) {
+                this.fuels.add(item);
+            }
+        }
+
+        this.equivalentCraftingStations.add(this.getTabItem());
+    }
+
+    @Override
+    public @NotNull ItemStack getTabItem() {
+        return new ItemStack(Blocks.INCINERATOR);
+    }
+
+    @Override
+    public ItemStack[][] getItems(int index, ItemStack filter) {
+        ItemStack[][] items = new ItemStack[this.recipesPerPage][];
+
+        for (int j = 0; j < this.recipesPerPage; ++j) {
+            items[j] = new ItemStack[this.slots.length];
+            int k = index + j;
+            if (k < this.recipes.size()) {
+                ItemStack[] recipe = this.recipes.get(k);
+
+                items[j][0] = recipe[0];
+                items[j][9] = recipe[1];
+                items[j][18] = this.fuels.get(this.rand.nextInt(this.fuels.size()));
+            }
+
+            if (items[j][0] == null && this.recipesOnThisPage > j) {
+                this.recipesOnThisPage = j;
+                this.redrawSlots = true;
+                break;
+            }
+
+            if (items[j][0] != null && this.recipesOnThisPage == j) {
+                this.recipesOnThisPage = j + 1;
+                this.redrawSlots = true;
+            }
+        }
+
+        return items;
+    }
+
+    @Override
+    public void updateRecipes(ItemStack filter, Boolean getUses) {
+        this.lastIndex = 0;
+        this.recipes.clear();
+
+        if (getUses && (filter != null)) {
+            ItemStack output = this.returnOutput(filter);
+            this.recipes.add(new ItemStack[]{filter.copy(), output});
+        } else if (filter != null) {
+            //TODO: hope that incinerator will have a loot table in the future
+            if (filter.getItemID() == Items.BONE.itemID) this.recipes.addAll(this.collectAllFood(new ItemStack(Items.BONE)));
+            if (filter.getItemID() == Items.DYE_POWDER.itemID && filter.getItemDamage() == 15) this.recipes.addAll(this.collectAllFood(new ItemStack(Items.DYE_POWDER, 1, 15)));
+            if (filter.getItemID() == Items.COAL.itemID) this.recipes.addAll(this.collectAllItems(new ItemStack(Items.COAL)));
+            if (filter.getItemID() == Items.ASH.itemID) this.recipes.addAll(this.collectAllItems(new ItemStack(Items.ASH)));
+        }
+
+        this.size = this.recipes.size();
+        super.updateRecipes(filter, getUses);
+        this.size = this.recipes.size();
+    }
+
+    private ItemStack returnOutput(ItemStack input) {
+        ItemStack output = new ItemStack(Items.ASH, 1, 0);
+        if (input.getItem() instanceof ItemFood) {
+            if (this.rand.nextInt(8) == 0) {
+                output = new ItemStack(Items.BONE, 1, 0);
+            } else if (this.rand.nextInt(4) == 0) {
+                output = new ItemStack(Items.DYE_POWDER, 1, 15);
+            } else if (this.rand.nextBoolean()) {
+                output = new ItemStack(Items.COAL, 1, 0);
+            }
+        } else if (this.rand.nextInt(8) == 0) {
+            output = new ItemStack(Items.COAL, 1, 0);
+        }
+        return output;
+    }
+
+
+    private Collection<ItemStack[]> collectAllFood(ItemStack output) {
+        final List<ItemStack[]> list = new ArrayList<>();
+        for (ItemStack item : Utils.itemList()) {
+            if (!TileEntityIncinerator.isItemValidFuel(item)) continue;
+            if (item.getItem() instanceof ItemFood) {
+                list.add(new ItemStack[]{item, output});
+            }
+        }
+        return list;
+    }
+
+    private Collection<ItemStack[]> collectAllItems(ItemStack output) {
+        final List<ItemStack[]> list = new ArrayList<>();
+        for (ItemStack item : Utils.itemList()) {
+            if(TileEntityIncinerator.isItemValidFuel(item)) {
+                list.add(new ItemStack[] {item, output});
+            }
+        }
+        return list;
+    }
+}

--- a/src/main/java/com/fox2code/howmanyfoxes/hmi/tabs/TabIncinerator.java
+++ b/src/main/java/com/fox2code/howmanyfoxes/hmi/tabs/TabIncinerator.java
@@ -4,11 +4,9 @@ import com.fox2code.howmanyfoxes.hmi.Utils;
 import net.minecraft.common.block.Blocks;
 import net.minecraft.common.block.data.Materials;
 import net.minecraft.common.block.tileentity.TileEntityIncinerator;
-import net.minecraft.common.item.Item;
 import net.minecraft.common.item.ItemStack;
 import net.minecraft.common.item.Items;
 import net.minecraft.common.item.children.ItemFood;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -17,10 +15,6 @@ import java.util.List;
 public class TabIncinerator extends TabWithTexture {
     private final ArrayList<ItemStack> fuels = new ArrayList<>();
     private final ArrayList<ItemStack[]> recipes = new ArrayList<>();
-
-    public static class DumbIncineratorRecord {
-
-    }
 
     public TabIncinerator(String tabCreator) {
         super(
@@ -61,7 +55,7 @@ public class TabIncinerator extends TabWithTexture {
     }
 
     @Override
-    public @NotNull ItemStack getTabItem() {
+    public ItemStack getTabItem() {
         return new ItemStack(Blocks.INCINERATOR);
     }
 
@@ -101,10 +95,11 @@ public class TabIncinerator extends TabWithTexture {
         this.recipes.clear();
 
         if (getUses && (filter != null)) {
-            ItemStack output = this.returnOutput(filter);
-            this.recipes.add(new ItemStack[]{filter.copy(), output});
+            if(TileEntityIncinerator.isItemValidFuel(filter)) {
+                this.recipes.add(new ItemStack[]{filter.copy(), this.returnOutput(filter)});
+            }
         } else if (filter != null) {
-            //TODO: hope that incinerator will have a loot table in the future
+            //TODO: hope that incinerator will have an output chances list in the future
             if (filter.getItemID() == Items.BONE.itemID) this.recipes.addAll(this.collectAllFood(new ItemStack(Items.BONE)));
             if (filter.getItemID() == Items.DYE_POWDER.itemID && filter.getItemDamage() == 15) this.recipes.addAll(this.collectAllFood(new ItemStack(Items.DYE_POWDER, 1, 15)));
             if (filter.getItemID() == Items.COAL.itemID) this.recipes.addAll(this.collectAllItems(new ItemStack(Items.COAL)));
@@ -116,6 +111,7 @@ public class TabIncinerator extends TabWithTexture {
         this.size = this.recipes.size();
     }
 
+    //TODO: Hope that incinerator will have a static method to give an output from input itemstack
     private ItemStack returnOutput(ItemStack input) {
         ItemStack output = new ItemStack(Items.ASH, 1, 0);
         if (input.getItem() instanceof ItemFood) {
@@ -131,7 +127,6 @@ public class TabIncinerator extends TabWithTexture {
         }
         return output;
     }
-
 
     private Collection<ItemStack[]> collectAllFood(ItemStack output) {
         final List<ItemStack[]> list = new ArrayList<>();


### PR DESCRIPTION
Fixes:
- Fixed a bug when using recipes viewer crashes either the game or the mod (caused by trash button).
- Fixed a bug when `View All Recipes`'s default `NONE` keybind will activate upon using `Win` key (remapped `View All Recipes` to `P`).
- Fixed a bug when plushies are rendered incorrectly in recipe viewers.
- Added support for viewing Incinerator recipes.